### PR TITLE
refactor: move PATCH seller update logic from handler to service layer

### DIFF
--- a/internal/handler/seller_handler.go
+++ b/internal/handler/seller_handler.go
@@ -5,7 +5,6 @@ import (
 	"ProyectoFinal/internal/service/seller"
 	"ProyectoFinal/pkg/errors"
 	"ProyectoFinal/pkg/models"
-	"fmt"
 	"github.com/bootcamp-go/web/request"
 	"github.com/bootcamp-go/web/response"
 	"log"
@@ -81,22 +80,7 @@ func (h *SellerHandler) Update() http.HandlerFunc {
 			return
 		}
 
-		sellerToUpdate, err := h.service.GetById(id)
-
-		if err != nil {
-			log.Println(err)
-			errors.HandleError(w, err)
-			return
-		}
-
-		if updated := utilsHandler.UpdateFields(&sellerToUpdate, &reqBody); !updated {
-			newError := fmt.Errorf("%w : no fields provided for update", errors.ErrUnprocessableEntity)
-			log.Println(newError)
-			errors.HandleError(w, newError)
-			return
-		}
-
-		sellerUpdated, err := h.service.Update(sellerToUpdate)
+		sellerUpdated, err := h.service.Update(id, &reqBody)
 
 		if err != nil {
 			log.Println(err)

--- a/internal/service/seller/seller_default.go
+++ b/internal/service/seller/seller_default.go
@@ -1,8 +1,12 @@
 package seller
 
 import (
+	"ProyectoFinal/internal/handler/utils"
 	"ProyectoFinal/internal/repository/seller"
+	"ProyectoFinal/pkg/errors"
 	"ProyectoFinal/pkg/models"
+	"fmt"
+	"log"
 )
 
 type SellerDefault struct {
@@ -51,11 +55,21 @@ func (s *SellerDefault) Delete(id int) error {
 	return nil
 }
 
-func (s *SellerDefault) Update(seller models.Seller) (models.Seller, error) {
-	_, err := s.repository.Update(&seller)
+func (s *SellerDefault) Update(id int, reqBody *models.UpdateSellerRequest) (models.Seller, error) {
+	sellerToUpdate, err := s.repository.GetById(id)
+
+	if err != nil {
+		return models.Seller{}, err
+	}
+	if !utils.UpdateFields(sellerToUpdate, reqBody) {
+		newError := fmt.Errorf("%w : no fields provided for update", errors.ErrUnprocessableEntity)
+		log.Println(newError)
+		return models.Seller{}, newError
+	}
+	_, err = s.repository.Update(sellerToUpdate)
 	if err != nil {
 		return models.Seller{}, err
 	}
 
-	return seller, nil
+	return *sellerToUpdate, nil
 }

--- a/internal/service/seller/seller_service.go
+++ b/internal/service/seller/seller_service.go
@@ -17,5 +17,5 @@ type SellerService interface {
 	Delete(id int) error
 
 	// Update modifies an existing seller.
-	Update(seller models.Seller) (models.Seller, error)
+	Update(id int, reqBody *models.UpdateSellerRequest) (models.Seller, error)
 }


### PR DESCRIPTION
Refactored the PATCH update logic by moving it from the handler layer to the service layer. This improves code organization, maintains separation of concerns, and makes the update flow easier to test and maintain.