### PR TITLE
Refactored update logic and implemented unit tests for handler

### DIFF
--- a/internal/application/di/warehouse_dependencies.go
+++ b/internal/application/di/warehouse_dependencies.go
@@ -1,7 +1,7 @@
 package di
 
 import (
-	handler "ProyectoFinal/internal/handler"
+	handler "ProyectoFinal/internal/handler/warehouse"
 	repository "ProyectoFinal/internal/repository/warehouse"
 	service "ProyectoFinal/internal/service/warehouse"
 	"database/sql"

--- a/internal/application/router/warehouse_router.go
+++ b/internal/application/router/warehouse_router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"ProyectoFinal/internal/handler"
+	handler "ProyectoFinal/internal/handler/warehouse"
 
 	"github.com/go-chi/chi/v5"
 )

--- a/internal/handler/warehouse/warehouse_handler.go
+++ b/internal/handler/warehouse/warehouse_handler.go
@@ -1,7 +1,8 @@
-package handler
+package warehouse
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"ProyectoFinal/internal/handler/utils"
@@ -61,7 +62,7 @@ func (h *WarehouseHandler) GetWarehouseById(w http.ResponseWriter, r *http.Reque
 func (h *WarehouseHandler) CreateWarehouse(w http.ResponseWriter, r *http.Request) {
 	var createRequest models.CreateWarehouseRequest
 	if err := json.NewDecoder(r.Body).Decode(&createRequest); err != nil {
-		errors.HandleError(w, errors.WrapErrBadRequest(err))
+		errors.HandleError(w, errors.WrapErrBadRequest(fmt.Errorf("it was not possible to decode json")))
 		return
 	}
 
@@ -93,7 +94,7 @@ func (h *WarehouseHandler) UpdateWarehouse(w http.ResponseWriter, r *http.Reques
 
 	var updateRequest models.UpdateWarehouseRequest
 	if err := json.NewDecoder(r.Body).Decode(&updateRequest); err != nil {
-		errors.HandleError(w, errors.WrapErrBadRequest(err))
+		errors.HandleError(w, errors.WrapErrBadRequest(fmt.Errorf("it was not possible to decode json")))
 		return
 	}
 

--- a/internal/handler/warehouse/warehouse_handler_test.go
+++ b/internal/handler/warehouse/warehouse_handler_test.go
@@ -1,0 +1,752 @@
+package warehouse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	customErrors "ProyectoFinal/pkg/errors"
+	"ProyectoFinal/pkg/models"
+
+	"ProyectoFinal/mocks"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllWarehouses_ValidRequest_Success(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	warehouses := []models.Warehouse{
+		{
+			ID:                 1,
+			WarehouseCode:      "1234567890",
+			Address:            "Address 1",
+			Telephone:          "1234567890",
+			MinimumCapacity:    10,
+			MinimumTemperature: 10,
+			LocalityId:         nil,
+			Locality:           nil,
+		},
+		{
+			ID:                 2,
+			WarehouseCode:      "1234567890",
+			Address:            "Address 2",
+			Telephone:          "1234567890",
+			MinimumCapacity:    10,
+			MinimumTemperature: 10,
+			LocalityId:         nil,
+			Locality:           nil,
+		},
+	}
+	expectedResponseBody := `
+	{
+		"data": [
+			{
+				"id":1,
+				"warehouse_code":"1234567890",
+				"address":"Address 1",
+				"telephone":"1234567890",
+				"minimum_capacity":10,
+				"minimum_temperature":10,
+				"locality":null
+			},
+			{
+				"id":2,
+				"warehouse_code":"1234567890",
+				"address":"Address 2",
+				"telephone":"1234567890",
+				"minimum_capacity":10,
+				"minimum_temperature":10,
+				"locality":null
+			}
+		]
+	}`
+
+	mockService.On("GetAllWarehouses").Return(warehouses, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/warehouses", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetAllWarehouses(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestGetAllWarehouses_ServiceError_InternalServerError(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	// Mock an unexpected service error (not a predefined error like NotFound, Conflict, etc.)
+	unexpectedError := errors.New("database connection failed")
+	expectedResponseBody := `{"status":"Internal Server Error","message":"Internal Server Error"}`
+
+	mockService.On("GetAllWarehouses").Return([]models.Warehouse{}, unexpectedError)
+
+	req := httptest.NewRequest(http.MethodGet, "/warehouses", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetAllWarehouses(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestGetWarehouseById_ValidId_Success(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	warehouse := models.Warehouse{
+		ID:                 1,
+		WarehouseCode:      "WH001",
+		Address:            "Address 1",
+		Telephone:          "1234567890",
+		MinimumCapacity:    100,
+		MinimumTemperature: -10.5,
+		LocalityId:         nil,
+		Locality:           nil,
+	}
+	expectedResponse := `{
+		"data": {
+			"id": 1,
+			"warehouse_code": "WH001",
+			"address": "Address 1",
+			"telephone": "1234567890",
+			"minimum_capacity": 100,
+			"minimum_temperature": -10.5,
+			"locality": null
+		}
+	}`
+
+	mockService.On("GetWarehouseById", 1).Return(warehouse, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/warehouses/1", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.GetWarehouseById(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, expectedResponse, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestGetWarehouseById_NonExistingId_NotFound(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	nonExistingId := 999
+	expectedError := customErrors.WrapErrNotFound("warehouse", "id", nonExistingId)
+	expectedResponseBody := `{"status":"Not Found","message":"not found : warehouse with id 999 not found"}`
+
+	mockService.On("GetWarehouseById", nonExistingId).Return(models.Warehouse{}, expectedError)
+
+	req := httptest.NewRequest(http.MethodGet, "/warehouses/999", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "999")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+
+	handler.GetWarehouseById(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestGetWarehouseById_InvalidId_BadRequest(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	expectedResponseBody := `{"status":"Bad Request","message":"bad request : id must be a number"}`
+
+	req := httptest.NewRequest(http.MethodGet, "/warehouses/abc", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.GetWarehouseById(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+}
+
+func TestCreateWarehouse_ValidRequest_Success(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+	createRequest := models.CreateWarehouseRequest{
+		WarehouseCode:      "WH001",
+		Address:            "Address 1",
+		Telephone:          "1234567890",
+		MinimumCapacity:    &[]int{100}[0],
+		MinimumTemperature: &[]float64{-10.5}[0],
+		LocalityId:         nil,
+	}
+	expectedWarehouse := models.Warehouse{
+		ID:                 1,
+		WarehouseCode:      "WH001",
+		Address:            "Address 1",
+		Telephone:          "1234567890",
+		MinimumCapacity:    100,
+		MinimumTemperature: -10.5,
+		LocalityId:         nil,
+		Locality:           nil,
+	}
+	expectedResponse := `{
+		"data": {
+			"id": 1,
+			"warehouse_code": "WH001",
+			"address": "Address 1",
+			"telephone": "1234567890",
+			"minimum_capacity": 100,
+			"minimum_temperature": -10.5,
+			"locality_id": null
+		}
+	}`
+
+	body, _ := json.Marshal(createRequest)
+	mockService.On("CreateWarehouse", createRequest.DocToModel()).Return(expectedWarehouse, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/warehouses", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.CreateWarehouse(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.JSONEq(t, expectedResponse, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestCreateWarehouse_InvalidRequest_UnprocessableEntity(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	testCases := []struct {
+		name                 string
+		requestBody          models.CreateWarehouseRequest
+		expectedResponseBody string
+	}{
+		{
+			name: "warehouse_code is required",
+			requestBody: models.CreateWarehouseRequest{
+				Address:            "Address 1",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.WarehouseCode' Error:Field validation for 'WarehouseCode' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "warehouse_code minimum length validation",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "",
+				Address:            "Address 1",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.WarehouseCode' Error:Field validation for 'WarehouseCode' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "address is required",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.Address' Error:Field validation for 'Address' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "address minimum length validation",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.Address' Error:Field validation for 'Address' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "telephone is required",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.Telephone' Error:Field validation for 'Telephone' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "telephone must be numeric",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				Telephone:          "12345abc90",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.Telephone' Error:Field validation for 'Telephone' failed on the 'numeric' tag"
+			}`,
+		},
+		{
+			name: "telephone minimum length validation",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				Telephone:          "123456",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.Telephone' Error:Field validation for 'Telephone' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "minimum_capacity is required",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				Telephone:          "1234567890",
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.MinimumCapacity' Error:Field validation for 'MinimumCapacity' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "minimum_capacity must be greater than 0",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{-1}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.MinimumCapacity' Error:Field validation for 'MinimumCapacity' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "minimum_temperature is required",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:   "WH001",
+				Address:         "Address 1",
+				Telephone:       "1234567890",
+				MinimumCapacity: &[]int{100}[0],
+				LocalityId:      nil,
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.MinimumTemperature' Error:Field validation for 'MinimumTemperature' failed on the 'required' tag"
+			}`,
+		},
+		{
+			name: "locality_id must be greater than 0",
+			requestBody: models.CreateWarehouseRequest{
+				WarehouseCode:      "WH001",
+				Address:            "Address 1",
+				Telephone:          "1234567890",
+				MinimumCapacity:    &[]int{100}[0],
+				MinimumTemperature: &[]float64{-10.5}[0],
+				LocalityId:         &[]int{0}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'CreateWarehouseRequest.LocalityId' Error:Field validation for 'LocalityId' failed on the 'gt' tag"
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.requestBody)
+			req := httptest.NewRequest(http.MethodPost, "/warehouses", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+
+			handler.CreateWarehouse(w, req)
+
+			require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+			require.JSONEq(t, tc.expectedResponseBody, w.Body.String())
+		})
+	}
+}
+
+func TestCreateWarehouse_DuplicateWarehouseCode_Conflict(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	createRequest := models.CreateWarehouseRequest{
+		WarehouseCode:      "WH001",
+		Address:            "Address 1",
+		Telephone:          "1234567890",
+		MinimumCapacity:    &[]int{100}[0],
+		MinimumTemperature: &[]float64{-10.5}[0],
+		LocalityId:         nil,
+	}
+	expectedError := customErrors.WrapErrConflict("warehouses", "warehouse_code", "WH001")
+	expectedResponseBody := `{"status":"Conflict","message":"conflict : warehouses with warehouse_code WH001 already exists"}`
+
+	mockService.On("CreateWarehouse", createRequest.DocToModel()).Return(models.Warehouse{}, expectedError)
+
+	body, _ := json.Marshal(createRequest)
+	req := httptest.NewRequest(http.MethodPost, "/warehouses", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.CreateWarehouse(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestCreateWarehouse_MalformedJson_BadRequest(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	malformedJson := `{warehouse_code: "WH001", "address": "Address 1"}}`
+	expectedResponseBody := `
+	{ 
+		"status":"Bad Request",
+		"message":"bad request : it was not possible to decode json"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/warehouses", bytes.NewReader([]byte(malformedJson)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.CreateWarehouse(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.JSONEq(t, expectedResponseBody, w.Body.String())
+}
+
+func TestUpdateWarehouse_ValidIdAndRequest_Success(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	updateRequest := models.UpdateWarehouseRequest{
+		WarehouseCode:      &[]string{"WH001-UPDATED"}[0],
+	}
+	updatedWarehouse := models.Warehouse{
+		ID:                 1,
+		WarehouseCode:      "WH001-UPDATED",
+		Address:            "Address 1",
+		Telephone:          "1234567890",
+		MinimumCapacity:    100,
+		MinimumTemperature: -10.5,
+		LocalityId:         nil,
+		Locality:           nil,
+	}
+	expectedResponse := `{
+		"data": {
+			"id": 1,
+			"warehouse_code": "WH001-UPDATED",
+			"address": "Address 1",
+			"telephone": "1234567890",
+			"minimum_capacity": 100,
+			"minimum_temperature": -10.5,
+			"locality_id": null
+		}
+	}`
+
+	mockService.On("UpdateWarehouse", 1, updateRequest).Return(updatedWarehouse, nil)
+
+	body, _ := json.Marshal(updateRequest)
+	req := httptest.NewRequest(http.MethodPut, "/warehouses/1", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.UpdateWarehouse(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, expectedResponse, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestUpdateWarehouse_NonExistingId_NotFound(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	nonExistingId := 999
+	updateRequest := models.UpdateWarehouseRequest{}
+	expectedError := customErrors.WrapErrNotFound("warehouse", "id", nonExistingId)
+	expectedResponseBody := `{"status":"Not Found","message":"not found : warehouse with id 999 not found"}`
+
+	mockService.On("UpdateWarehouse", nonExistingId, updateRequest).Return(models.Warehouse{}, expectedError)
+
+	body, _ := json.Marshal(updateRequest)
+	req := httptest.NewRequest(http.MethodPut, "/warehouses/999", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "999")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.UpdateWarehouse(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestUpdateWarehouse_InvalidRequest_UnprocessableEntity(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	testCases := []struct {
+		name                 string
+		requestBody          models.UpdateWarehouseRequest
+		expectedResponseBody string
+	}{
+		{
+			name: "warehouse_code minimum length validation",
+			requestBody: models.UpdateWarehouseRequest{
+				WarehouseCode:      &[]string{""}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.WarehouseCode' Error:Field validation for 'WarehouseCode' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "address minimum length validation",
+			requestBody: models.UpdateWarehouseRequest{
+				Address: &[]string{""}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.Address' Error:Field validation for 'Address' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "telephone must be numeric",
+			requestBody: models.UpdateWarehouseRequest{
+				Telephone: &[]string{"12345abc90"}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.Telephone' Error:Field validation for 'Telephone' failed on the 'numeric' tag"
+			}`,
+		},
+		{
+			name: "telephone minimum length validation",
+			requestBody: models.UpdateWarehouseRequest{
+				Telephone: &[]string{"123456"}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.Telephone' Error:Field validation for 'Telephone' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "minimum_capacity must be greater than 0",
+			requestBody: models.UpdateWarehouseRequest{
+				MinimumCapacity: &[]int{-1}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.MinimumCapacity' Error:Field validation for 'MinimumCapacity' failed on the 'min' tag"
+			}`,
+		},
+		{
+			name: "locality_id must be greater than 0",
+			requestBody: models.UpdateWarehouseRequest{
+				LocalityId: &[]int{0}[0],
+			},
+			expectedResponseBody: `
+			{ 
+				"status":"Unprocessable Entity",
+				"message": "unprocessable entity : Key: 'UpdateWarehouseRequest.LocalityId' Error:Field validation for 'LocalityId' failed on the 'gt' tag"
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.requestBody)
+			req := httptest.NewRequest(http.MethodPut, "/warehouses/1", bytes.NewReader(body))
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", "1")
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			w := httptest.NewRecorder()
+
+			handler.UpdateWarehouse(w, req)
+
+			require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+			require.JSONEq(t, tc.expectedResponseBody, w.Body.String())
+		})
+	}
+}
+
+func TestUpdateWarehouse_DuplicateWarehouseCode_Conflict(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	updateRequest := models.UpdateWarehouseRequest{
+		WarehouseCode:      &[]string{"WH002"}[0],
+	}
+	expectedError := customErrors.WrapErrConflict("warehouses", "warehouse_code", "WH002")
+	expectedResponseBody := `{"status":"Conflict","message":"conflict : warehouses with warehouse_code WH002 already exists"}`
+
+	mockService.On("UpdateWarehouse", 1, updateRequest).Return(models.Warehouse{}, expectedError).Once()
+
+	body, _ := json.Marshal(updateRequest)
+	req := httptest.NewRequest(http.MethodPut, "/warehouses/1", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.UpdateWarehouse(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestUpdateWarehouse_BadData_BadRequest(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	tests := []struct {
+		name string
+		id string
+		requestBodyJson string
+		expectedResponseBody string
+	}{
+		{
+			name: "invalid id",
+			id: "abc",
+			requestBodyJson: ``,
+			expectedResponseBody: `{"status":"Bad Request","message":"bad request : id must be a number"}`,
+		},
+		{
+			name: "malformed json",
+			id: "1",
+			requestBodyJson: `{warehouse_code: "WH001-UPDATED", "address": "Address Updated"}`,
+			expectedResponseBody: `
+			{ 
+				"status":"Bad Request",
+				"message":"bad request : it was not possible to decode json"
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/warehouses/" + test.id, bytes.NewReader([]byte(test.requestBodyJson)))
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.id)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			w := httptest.NewRecorder()
+
+			handler.UpdateWarehouse(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.JSONEq(t, test.expectedResponseBody, w.Body.String())
+		})
+	}
+}
+
+func TestDeleteWarehouse_NonExistingId_NotFound(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	nonExistingId := 999
+	expectedError := customErrors.WrapErrNotFound("warehouse", "id", nonExistingId)
+	expectedResponseBody := `{"status":"Not Found","message":"not found : warehouse with id 999 not found"}`
+
+	mockService.On("DeleteWarehouse", nonExistingId).Return(expectedError)
+
+	req := httptest.NewRequest(http.MethodDelete, "/warehouses/999", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "999")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.DeleteWarehouse(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestDeleteWarehouse_InvalidId_BadRequest(t *testing.T) {
+	mockService := new(mocks.MockWarehouseService)
+	handler := NewWarehouseHandler(mockService)
+
+	expectedResponseBody := `{"status":"Bad Request","message":"bad request : id must be a number"}`
+
+	req := httptest.NewRequest(http.MethodDelete, "/warehouses/abc", nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handler.DeleteWarehouse(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Equal(t, expectedResponseBody, w.Body.String())
+}

--- a/internal/handler/warehouse_handler.go
+++ b/internal/handler/warehouse_handler.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"ProyectoFinal/internal/handler/utils"
@@ -103,19 +102,7 @@ func (h *WarehouseHandler) UpdateWarehouse(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	currentWarehouse, err := h.warehouseService.GetWarehouseById(id)
-	if err != nil {
-		errors.HandleError(w, err)
-		return
-	}
-
-	if updated := utils.UpdateFields(&currentWarehouse, &updateRequest); !updated {
-		newError := errors.WrapErrUnprocessableEntity(fmt.Errorf("no fields provided for update"))
-		errors.HandleError(w, newError)
-		return
-	}
-
-	updatedWarehouse, err := h.warehouseService.UpdateWarehouse(id, currentWarehouse)
+	updatedWarehouse, err := h.warehouseService.UpdateWarehouse(id, updateRequest)
 	if err != nil {
 		errors.HandleError(w, err)
 		return

--- a/internal/service/utils/update_util.go
+++ b/internal/service/utils/update_util.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"reflect"
+)
+
+// UpdateFields compares the source struct (request body) with the target struct (the existing record).
+// For each non-nil pointer field in the source, the corresponding field in the target is updated in memory.
+// Returns true if any fields are updated, false otherwise.
+func UpdateFields(target interface{}, source interface{}) bool {
+	targetReflect := reflect.ValueOf(target)
+	sourceReflect := reflect.ValueOf(source)
+
+	if targetReflect.Kind() != reflect.Ptr || targetReflect.Elem().Kind() != reflect.Struct {
+		return false
+	}
+	if sourceReflect.Kind() != reflect.Ptr || sourceReflect.Elem().Kind() != reflect.Struct {
+		return false
+	}
+
+	targetValue := targetReflect.Elem()
+	sourceValue := sourceReflect.Elem()
+	sourceType := sourceValue.Type()
+
+	updated := false
+
+	for i := 0; i < sourceValue.NumField(); i++ {
+		field := sourceValue.Field(i)
+		fieldName := sourceType.Field(i).Name
+		if field.Kind() == reflect.Ptr && !field.IsNil() {
+			targetField := targetValue.FieldByName(fieldName)
+			if targetField.IsValid() && targetField.CanSet() {
+				//When target is also a pointer value assign the pointer value
+				if targetField.Kind() == reflect.Ptr {
+					targetField.Set(field)
+					updated = true
+				} else if targetField.Type() == field.Elem().Type() {
+					// When target is a value, but source is pointer
+					targetField.Set(field.Elem())
+					updated = true
+				}
+			}
+		}
+	}
+
+	return updated
+}

--- a/internal/service/warehouse/warehouse_default.go
+++ b/internal/service/warehouse/warehouse_default.go
@@ -2,7 +2,10 @@ package warehouse
 
 import (
 	"ProyectoFinal/internal/repository/warehouse"
+	"ProyectoFinal/internal/service/utils"
+	customErrors "ProyectoFinal/pkg/errors"
 	"ProyectoFinal/pkg/models"
+	"fmt"
 )
 
 type WarehouseServiceImpl struct {
@@ -39,14 +42,17 @@ func (s *WarehouseServiceImpl) CreateWarehouse(warehouse models.Warehouse) (mode
 	return wh, nil
 }
 
-func (s *WarehouseServiceImpl) UpdateWarehouse(id int, warehouse models.Warehouse) (models.Warehouse, error) {
-	_, err := s.warehouseRepo.GetById(id)
+func (s *WarehouseServiceImpl) UpdateWarehouse(id int, warehouseUpdate models.UpdateWarehouseRequest) (models.Warehouse, error) {
+	existingWarehouse, err := s.warehouseRepo.GetById(id)
 	if err != nil {
 		return models.Warehouse{}, err
 	}
 
-	warehouse.ID = id
-	updatedWarehouse, err := s.warehouseRepo.Update(id, warehouse)
+	if updated := utils.UpdateFields(existingWarehouse, &warehouseUpdate); !updated {
+		return models.Warehouse{}, customErrors.WrapErrUnprocessableEntity(fmt.Errorf("no fields provided for update"))
+	}
+
+	updatedWarehouse, err := s.warehouseRepo.Update(id, *existingWarehouse)
 	if err != nil {
 		return models.Warehouse{}, err
 	}

--- a/internal/service/warehouse/warehouse_service.go
+++ b/internal/service/warehouse/warehouse_service.go
@@ -6,6 +6,6 @@ type WarehouseService interface {
 	GetAllWarehouses() ([]models.Warehouse, error)
 	GetWarehouseById(id int) (models.Warehouse, error)
 	CreateWarehouse(warehouse models.Warehouse) (models.Warehouse, error)
-	UpdateWarehouse(id int, warehouse models.Warehouse) (models.Warehouse, error)
+	UpdateWarehouse(id int, warehouse models.UpdateWarehouseRequest) (models.Warehouse, error)
 	DeleteWarehouse(id int) error
 }

--- a/mocks/warehouse_mock.go
+++ b/mocks/warehouse_mock.go
@@ -26,7 +26,7 @@ func (m *MockWarehouseService) CreateWarehouse(warehouse models.Warehouse) (mode
 	return args.Get(0).(models.Warehouse), args.Error(1)
 }
 
-func (m *MockWarehouseService) UpdateWarehouse(id int, warehouse models.Warehouse) (models.Warehouse, error) {
+func (m *MockWarehouseService) UpdateWarehouse(id int, warehouse models.UpdateWarehouseRequest) (models.Warehouse, error) {
 	args := m.Called(id, warehouse)
 	return args.Get(0).(models.Warehouse), args.Error(1)
 }


### PR DESCRIPTION
I moved the logic for the update from the handler to the service, this way the handler doesn't have to make 2 calls to service in order to get a warehouse and then update. Later, I added the unit tests for the warehouse handler.