### PR TITLE
Feat: implemented unit test for 'ReportCarriersByLocaity' repo method

### DIFF
--- a/internal/repository/locality/locality_mysql_test.go
+++ b/internal/repository/locality/locality_mysql_test.go
@@ -4,9 +4,10 @@ import (
 	pkgErrors "ProyectoFinal/pkg/errors"
 	"ProyectoFinal/pkg/models"
 	"errors"
+	"testing"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLocalityMysql_Create_QueryError(t *testing.T) {
@@ -315,5 +316,162 @@ func TestLocalityMysql_GetSellersByLocalities_Success(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, expectedLocalitiesReport, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_Success(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	localityId := 1
+	expectedReports := []models.CarrierReport{
+		{
+			LocalityId:    1,
+			LocalityName:  "Buenos Aires",
+			CarriersCount: 3,
+		},
+	}
+	rows := sqlmock.NewRows([]string{
+		"id", "locality_name", "carriers_count",
+	}).
+		AddRow(1, "Buenos Aires", 3)
+
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(localityId, localityId).
+		WillReturnRows(rows)
+
+	result, err := repo.ReportCarriersByLocality(&localityId)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedReports, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_LocalityIdIsNil_ReturnsAllLocalities(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	expectedReports := []models.CarrierReport{
+		{
+			LocalityId:    1,
+			LocalityName:  "Buenos Aires",
+			CarriersCount: 3,
+		},
+		{
+			LocalityId:    2,
+			LocalityName:  "Córdoba",
+			CarriersCount: 1,
+		},
+		{
+			LocalityId:    3,
+			LocalityName:  "Rosario",
+			CarriersCount: 2,
+		},
+	}
+	rows := sqlmock.NewRows([]string{
+		"id", "locality_name", "carriers_count",
+	}).
+		AddRow(1, "Buenos Aires", 3).
+		AddRow(2, "Córdoba", 1).
+		AddRow(3, "Rosario", 2)
+
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(nil, nil).
+		WillReturnRows(rows)
+
+	result, err := repo.ReportCarriersByLocality(nil)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedReports, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_QueryError_ReturnsError(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	localityId := 1
+	expectedError := errors.New("connection with db was broken and failed")
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(localityId, localityId).
+		WillReturnError(expectedError)
+
+	result, err := repo.ReportCarriersByLocality(&localityId)
+
+	require.Error(t, err)
+	require.Equal(t, expectedError, err)
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_ScanError_ReturnsError(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	localityId := 1
+	rows := sqlmock.NewRows([]string{
+		"id", "locality_name", "carriers_count",
+	}).
+		AddRow("invalid_id", "Buenos Aires", 3) // invalid_id is not an int
+
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(localityId, localityId).
+		WillReturnRows(rows)
+
+	result, err := repo.ReportCarriersByLocality(&localityId)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_RowsErrError_ReturnsError(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	localityId := 1
+	expectedError := errors.New("rows iteration error")
+	rows := sqlmock.NewRows([]string{
+		"id", "locality_name", "carriers_count",
+	}).
+		AddRow(1, "Buenos Aires", 3).
+		CloseError(expectedError)
+
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(localityId, localityId).
+		WillReturnRows(rows)
+
+	result, err := repo.ReportCarriersByLocality(&localityId)
+
+	require.Error(t, err)
+	require.Equal(t, expectedError, err)
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReportCarriersByLocality_NoDataFound_ReturnsErrNotFound(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repo := NewLocalityMysqlRepository(db)
+
+	localityId := 999
+
+	rows := sqlmock.NewRows([]string{
+		"id", "locality_name", "carriers_count",
+	})
+	mock.ExpectQuery("^SELECT (.+) FROM localities l (.+)").
+		WithArgs(localityId, localityId).
+		WillReturnRows(rows)
+
+	result, err := repo.ReportCarriersByLocality(&localityId)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, pkgErrors.ErrNotFound)
+	require.Nil(t, result)
 	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
in this commit i only implemented unit test for the method ReportCarriersByLocality defined on the locality repository interface. With this change, the test coverage of the repository is now 100%.