### PR TITLE
refactor: separate section and product batch mocks by type

### DIFF
--- a/mocks/product_batch/product_batch_repository_mock.go
+++ b/mocks/product_batch/product_batch_repository_mock.go
@@ -6,24 +6,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// MockProductBatchService - implementation of product batch service interface
-type MockProductBatchService struct {
-	mock.Mock
-}
-
-func (m *MockProductBatchService) Create(productBatch models.ProductBatch) (models.ProductBatch, error) {
-	args := m.Called(productBatch)
-	return args.Get(0).(models.ProductBatch), args.Error(1)
-}
-
-func (m *MockProductBatchService) GetProductCountBySection(sectionID *int) ([]models.SectionProductReport, error) {
-	args := m.Called(sectionID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]models.SectionProductReport), args.Error(1)
-}
-
 // MockProductBatchRepository - implementation of product batch repository interface
 type MockProductBatchRepository struct {
 	mock.Mock

--- a/mocks/product_batch/product_batch_service_mock.go
+++ b/mocks/product_batch/product_batch_service_mock.go
@@ -1,0 +1,25 @@
+package product_batch
+
+import (
+	"ProyectoFinal/pkg/models"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockProductBatchService - implementation of product batch service interface
+type MockProductBatchService struct {
+	mock.Mock
+}
+
+func (m *MockProductBatchService) Create(productBatch models.ProductBatch) (models.ProductBatch, error) {
+	args := m.Called(productBatch)
+	return args.Get(0).(models.ProductBatch), args.Error(1)
+}
+
+func (m *MockProductBatchService) GetProductCountBySection(sectionID *int) ([]models.SectionProductReport, error) {
+	args := m.Called(sectionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.SectionProductReport), args.Error(1)
+}

--- a/mocks/section/section_repository_mock.go
+++ b/mocks/section/section_repository_mock.go
@@ -6,41 +6,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// MockSectionService - implementation of section interface
-type MockSectionService struct {
-	mock.Mock
-}
-
-func (m *MockSectionService) GetAll() ([]models.Section, error) {
-	args := m.Called()
-	return args.Get(0).([]models.Section), args.Error(1)
-}
-
-func (m *MockSectionService) GetById(id int) (models.Section, error) {
-	args := m.Called(id)
-	return args.Get(0).(models.Section), args.Error(1)
-}
-
-func (m *MockSectionService) Create(section models.Section) (models.Section, error) {
-	args := m.Called(section)
-	return args.Get(0).(models.Section), args.Error(1)
-}
-
-func (m *MockSectionService) Update(id int, section models.Section) (models.Section, error) {
-	args := m.Called(id, section)
-	return args.Get(0).(models.Section), args.Error(1)
-}
-
-func (m *MockSectionService) UpdateWithValidation(id int, updateRequest models.UpdateSectionRequest) (models.Section, error) {
-	args := m.Called(id, updateRequest)
-	return args.Get(0).(models.Section), args.Error(1)
-}
-
-func (m *MockSectionService) Delete(id int) error {
-	args := m.Called(id)
-	return args.Error(0)
-}
-
 // MockSectionRepository - implementation of section repository interface
 type MockSectionRepository struct {
 	mock.Mock

--- a/mocks/section/section_service_mock.go
+++ b/mocks/section/section_service_mock.go
@@ -1,0 +1,42 @@
+package section
+
+import (
+	"ProyectoFinal/pkg/models"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSectionService - implementation of section interface
+type MockSectionService struct {
+	mock.Mock
+}
+
+func (m *MockSectionService) GetAll() ([]models.Section, error) {
+	args := m.Called()
+	return args.Get(0).([]models.Section), args.Error(1)
+}
+
+func (m *MockSectionService) GetById(id int) (models.Section, error) {
+	args := m.Called(id)
+	return args.Get(0).(models.Section), args.Error(1)
+}
+
+func (m *MockSectionService) Create(section models.Section) (models.Section, error) {
+	args := m.Called(section)
+	return args.Get(0).(models.Section), args.Error(1)
+}
+
+func (m *MockSectionService) Update(id int, section models.Section) (models.Section, error) {
+	args := m.Called(id, section)
+	return args.Get(0).(models.Section), args.Error(1)
+}
+
+func (m *MockSectionService) UpdateWithValidation(id int, updateRequest models.UpdateSectionRequest) (models.Section, error) {
+	args := m.Called(id, updateRequest)
+	return args.Get(0).(models.Section), args.Error(1)
+}
+
+func (m *MockSectionService) Delete(id int) error {
+	args := m.Called(id)
+	return args.Error(0)
+}


### PR DESCRIPTION
- Split section mocks into section_service_mock.go and section_repository_mock.go
- Split product batch mocks into product_batch_service_mock.go and product_batch_repository_mock.go
- Follow naming convention: {entity}_{type}_mock.go
- Maintain all existing functionality and test coverage
- Improve code organization and maintainability